### PR TITLE
Bump bktec to v1.1.0-rc.2

### DIFF
--- a/cypress/bin/test
+++ b/cypress/bin/test
@@ -6,7 +6,7 @@ npm install
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
 apt-get update && apt-get install curl -y
-curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.1/bktec_1.1.0-rc.1_linux_amd64 -o ./bktec
+curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.2/bktec_1.1.0-rc.2_linux_amd64 -o ./bktec
 chmod +x ./bktec
 
 # Configure Buildkite Test Engine Client

--- a/jest/bin/test
+++ b/jest/bin/test
@@ -5,7 +5,7 @@ npm install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.1/bktec_1.1.0-rc.1_linux_amd64 -o ./bktec
+curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.2/bktec_1.1.0-rc.2_linux_amd64 -o ./bktec
 chmod +x ./bktec
 
 # Configure Buildkite Test Engine Client

--- a/playwright/bin/test
+++ b/playwright/bin/test
@@ -5,7 +5,7 @@ npm install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.1/bktec_1.1.0-rc.1_linux_amd64 -o ./bktec
+curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.2/bktec_1.1.0-rc.2_linux_amd64 -o ./bktec
 chmod +x ./bktec
 
 # Configure Buildkite Test Engine Client

--- a/rspec/bin/test
+++ b/rspec/bin/test
@@ -5,7 +5,7 @@ bundle install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.1/bktec_1.1.0-rc.1_linux_amd64 -o ./bktec
+curl -L https://github.com/buildkite/test-engine-client/releases/download/v1.1.0-rc.2/bktec_1.1.0-rc.2_linux_amd64 -o ./bktec
 chmod +x ./bktec
 
 # Configure Buildkite Test Engine Client


### PR DESCRIPTION
Bump bktec to [v1.1.0-rc.2](https://github.com/buildkite/test-engine-client/releases/tag/v1.1.0-rc.2) that includes fixes for Jest retry.