### PR TITLE
Support nested tests for Jest and Playwright

### DIFF
--- a/jest/src/failed.test.js
+++ b/jest/src/failed.test.js
@@ -1,3 +1,5 @@
-test('adds 1 + 2 to equal 2', () => {
-  expect(1 + 2).toBe(2);
+describe('failed test', () => {
+  test('adds 1 + 2 to equal 2', () => {
+    expect(1 + 2).toBe(2);
+  });
 });

--- a/playwright/tests/example.spec.js
+++ b/playwright/tests/example.spec.js
@@ -1,19 +1,24 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test('has title', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test.describe('playwright.dev', () => {
+  test('has title', async ({ page }) => {
+    await page.goto('https://playwright.dev/');
 
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Playwright/);
-});
+    // Expect a title "to contain" a substring.
+    await expect(page).toHaveTitle(/Playwright/);
+  });
 
-test('get started link', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+  test.describe('nested', () => {
 
-  // Click the get started link.
-  await page.getByRole('link', { name: 'Get started' }).click();
+    test('get started link', async ({ page }) => {
+      await page.goto('https://playwright.dev/');
 
-  // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+      // Click the get started link.
+      await page.getByRole('link', { name: 'Get started' }).click();
+
+      // Expects page to have a heading with the name of Installation.
+      await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+    });
+  })
 });

--- a/playwright/tests/failed.spec.js
+++ b/playwright/tests/failed.spec.js
@@ -1,5 +1,7 @@
 const { test, expect } = require('@playwright/test');
 
-test('failed', () => {
-  expect(1).toBe(2);
+test.describe('test group', () => {
+  test('failed', () => {
+    expect(1).toBe(2);
+  });
 })


### PR DESCRIPTION
To verify that the scope for nested tests in Jest and Playwright is correctly generated