### PR TITLE
CI: use Buildkite hosted agents with cluster secrets

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,13 @@
 steps:
   - label: ":rspec: RSpec"
     parallelism: 2
-    command: "bin/test"
+    command: "cd rspec && bin/test"
     soft_fail: true
     plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client-examples
-      - aws-ssm#v1.0.0:
-          parameters:
-            BUILDKITE_ANALYTICS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-suite-token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-api-access-token
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
+            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
       - docker#v5.11.0:
           image: "ruby:3.3-bookworm"
           # Pass pipeline env variables to the Docker container
@@ -19,20 +17,16 @@ steps:
           environment:
             - BUILDKITE_ANALYTICS_TOKEN
             - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-      - thedyrt/change-directory#v0.1.1:
-          cd: rspec
-  
+
   - label: ":jest: Jest"
     parallelism: 2
-    command: "bin/test"
+    command: "cd jest && bin/test"
     soft_fail: true
     plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client-examples
-      - aws-ssm#v1.0.0:
-          parameters:
-            BUILDKITE_ANALYTICS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-suite-token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-api-access-token
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
+            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
       - docker#v5.11.0:
           image: "node:23.1.0-bookworm"
           # Pass pipeline env variables to the Docker container
@@ -42,23 +36,20 @@ steps:
           environment:
             - BUILDKITE_ANALYTICS_TOKEN
             - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-      - thedyrt/change-directory#v0.1.1:
-          cd: jest
-  
+
   - label: ":cypress: Cypress"
     parallelism: 2
-    command: "bin/test"
+    command: "cd cypress && bin/test"
     soft_fail: true
     plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client-examples
-      - aws-ssm#v1.0.0:
-          parameters:
-            BUILDKITE_ANALYTICS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-suite-token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-api-access-token
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
+            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
       - docker#v5.11.0:
           image: "cypress/included:13.15.1"
           entrypoint: ""
+          shell: ["/bin/sh", "-e", "-c"]
           # Pass pipeline env variables to the Docker container
           # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
           propagate-environment: true
@@ -66,20 +57,16 @@ steps:
           environment:
             - BUILDKITE_ANALYTICS_TOKEN
             - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-      - thedyrt/change-directory#v0.1.1:
-          cd: cypress
 
   - label: ":playwright: Playwright"
     parallelism: 2
-    command: "bin/test"
+    command: "cd playwright && bin/test"
     soft_fail: true
     plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client-examples
-      - aws-ssm#v1.0.0:
-          parameters:
-            BUILDKITE_ANALYTICS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-suite-token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: /pipelines/buildkite/test-engine-client-examples/test-engine-api-access-token
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
+            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
       - docker#v5.11.0:
           image: "mcr.microsoft.com/playwright:v1.48.1-noble"
           # Pass pipeline env variables to the Docker container
@@ -89,5 +76,3 @@ steps:
           environment:
             - BUILDKITE_ANALYTICS_TOKEN
             - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-      - thedyrt/change-directory#v0.1.1:
-          cd: playwright


### PR DESCRIPTION
Move to Buildkite hosted agents, and use the [cluster-secrets plugin](https://github.com/buildkite-plugins/cluster-secrets-buildkite-plugin) to access the suite and API token from [Buildkite secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets).

I've also replaced the third-party `thedyrt/change-directory` plugin usage with `cd …` in the `command` to reduce dependencies/risk and keep things concise.