### PR TITLE
Ruby Minitest example added (`test-collector-ruby`, but no `bktec`)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: ":rspec: RSpec"
+  - label: ":ruby: :rspec: Ruby: RSpec"
     parallelism: 2
     command: "cd rspec && bin/test"
     soft_fail: true
@@ -9,7 +9,25 @@ steps:
             BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
             BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
       - docker#v5.11.0:
-          image: "ruby:3.3-bookworm"
+          image: "ruby:3.4-bookworm" # requires curl
+          # Pass pipeline env variables to the Docker container
+          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          propagate-environment: true
+          # Pass API access token and Test Engine suite token to the Docker container
+          environment:
+            - BUILDKITE_ANALYTICS_TOKEN
+            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
+
+  - label: ":ruby: Ruby: Minitest"
+    command: "cd ruby-minitest && bin/test"
+    soft_fail: true
+    plugins:
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
+            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
+      - docker#v5.11.0:
+          image: "ruby:3.4-slim"
           # Pass pipeline env variables to the Docker container
           # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
           propagate-environment: true

--- a/ruby-minitest/Gemfile
+++ b/ruby-minitest/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "minitest"
+gem "buildkite-test_collector"

--- a/ruby-minitest/Gemfile.lock
+++ b/ruby-minitest/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    buildkite-test_collector (2.8.0)
+    minitest (5.25.4)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  buildkite-test_collector
+  minitest
+
+BUNDLED WITH
+   2.6.2

--- a/ruby-minitest/bin/test
+++ b/ruby-minitest/bin/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Install gems
+bundle install
+
+# Run Minitest
+bundle exec ruby -Ilib:test example_test.rb

--- a/ruby-minitest/example_test.rb
+++ b/ruby-minitest/example_test.rb
@@ -1,0 +1,25 @@
+require "minitest/autorun"
+
+require "buildkite/test_collector"
+Buildkite::TestCollector.configure(
+  hook: :minitest,
+  url: ENV["BUILDKITE_ANALYTICS_ENDPOINT"], # https://github.com/buildkite/test-collector-ruby/pull/239
+  tags: {
+    "test.framework.name" => "minitest",
+    "test.framework.version" => Minitest::VERSION,
+  },
+)
+
+class ExampleTest < Minitest::Test
+  def test_it_works
+    assert_equal true, true
+  end
+
+  def test_it_fails
+    assert_equal true, false
+  end
+
+  def test_it_flakes
+    assert_operator rand, :<=, 0.8
+  end
+end


### PR DESCRIPTION
_Based on #6_

Add an example for [Ruby Minitest](https://github.com/minitest/minitest), which uses the same [`test-collector-ruby` collector](https://github.com/buildkite/test-collector-ruby) as RSpec, but does not have bktec support yet.