### PR TITLE
RSpec: tag executions with `test.framework.name` & `test.framework.version`

### DIFF
--- a/rspec/spec/spec_helper.rb
+++ b/rspec/spec/spec_helper.rb
@@ -2,4 +2,10 @@ require 'buildkite/test_collector'
 
 # Configure the test collector to send the test results to Buildkite Test Engine
 # See https://buildkite.com/docs/test-engine/ruby-collectors
-Buildkite::TestCollector.configure(hook: :rspec)
+Buildkite::TestCollector.configure(
+  hook: :rspec,
+  tags: {
+    "test.framework.name" => "rspec",
+    "test.framework.version" => RSpec::Version::STRING,
+  },
+)


### PR DESCRIPTION
_Based on #6_ 

Add tags to the upload from the RSpec suite:
- `test.framework.name`
- `test.framework.version`