### PR TITLE
Upload `test.framework.*` tags from JS suites (cypress, jest, playwright)

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -10,5 +10,9 @@ module.exports = defineConfig({
   reporter: "buildkite-test-collector/cypress/reporter",
   reporterOptions: {
     token_name: "BUILDKITE_ANALYTICS_TOKEN",
+    tags: {
+      "test.framework.name": "cypress",
+      "test.framework.version": require('cypress/package.json').version,
+    },
   },
 })

--- a/cypress/package-lock.json
+++ b/cypress/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "buildkite-test-collector": "^1.7.3",
+        "buildkite-test-collector": "^1.8.0",
         "cypress": "^13.15.1"
       }
     },
@@ -339,10 +339,18 @@
       }
     },
     "node_modules/buildkite-test-collector": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.7.3.tgz",
-      "integrity": "sha512-4NJFY9h6r1gpF6Faxpxd/OPesHJQZNbFDtHSHDgzT6mJ8zteKM2jvNXRu0hP/+SO1pJ4oFyWr44x2WmbTTCn9Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.8.0.tgz",
+      "integrity": "sha512-N/J4tU+mac8JBwOupBM6Z03P462wG9t3h4uSp3wkvNB8z//0wm8RRuPE25rhnpvrFdZJJ5l9bd8vPXdRNkCrBA==",
       "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/jest",
+        "examples/jasmine",
+        "examples/mocha",
+        "examples/playwright",
+        "examples/cypress"
+      ],
       "dependencies": {
         "axios": "^1.6.8",
         "dotenv": "^16.0.2",
@@ -2298,9 +2306,9 @@
       "dev": true
     },
     "buildkite-test-collector": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.7.3.tgz",
-      "integrity": "sha512-4NJFY9h6r1gpF6Faxpxd/OPesHJQZNbFDtHSHDgzT6mJ8zteKM2jvNXRu0hP/+SO1pJ4oFyWr44x2WmbTTCn9Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.8.0.tgz",
+      "integrity": "sha512-N/J4tU+mac8JBwOupBM6Z03P462wG9t3h4uSp3wkvNB8z//0wm8RRuPE25rhnpvrFdZJJ5l9bd8vPXdRNkCrBA==",
       "dev": true,
       "requires": {
         "axios": "^1.6.8",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "buildkite-test-collector": "^1.7.3",
+    "buildkite-test-collector": "^1.8.0",
     "cypress": "^13.15.1"
   },
   "scripts": {

--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -2,7 +2,12 @@ const config = {
   reporters: [
     'default',
     // Send results to Test Engine
-    'buildkite-test-collector/jest/reporter'
+    ['buildkite-test-collector/jest/reporter', {
+      tags: {
+        "test.framework.name": "jest",
+        "test.framework.version": require("jest/package.json").version,
+      }
+    }]
   ],
 
   // Enable column + line capture for Test Engine

--- a/jest/package-lock.json
+++ b/jest/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "buildkite-test-collector": "^1.7.3",
+        "buildkite-test-collector": "^1.8.0",
         "jest": "^29.7.0"
       }
     },
@@ -1141,10 +1141,18 @@
       "license": "MIT"
     },
     "node_modules/buildkite-test-collector": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.7.3.tgz",
-      "integrity": "sha512-4NJFY9h6r1gpF6Faxpxd/OPesHJQZNbFDtHSHDgzT6mJ8zteKM2jvNXRu0hP/+SO1pJ4oFyWr44x2WmbTTCn9Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.8.0.tgz",
+      "integrity": "sha512-N/J4tU+mac8JBwOupBM6Z03P462wG9t3h4uSp3wkvNB8z//0wm8RRuPE25rhnpvrFdZJJ5l9bd8vPXdRNkCrBA==",
       "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/jest",
+        "examples/jasmine",
+        "examples/mocha",
+        "examples/playwright",
+        "examples/cypress"
+      ],
       "dependencies": {
         "axios": "^1.6.8",
         "dotenv": "^16.0.2",
@@ -4037,9 +4045,9 @@
       "dev": true
     },
     "buildkite-test-collector": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.7.3.tgz",
-      "integrity": "sha512-4NJFY9h6r1gpF6Faxpxd/OPesHJQZNbFDtHSHDgzT6mJ8zteKM2jvNXRu0hP/+SO1pJ4oFyWr44x2WmbTTCn9Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.8.0.tgz",
+      "integrity": "sha512-N/J4tU+mac8JBwOupBM6Z03P462wG9t3h4uSp3wkvNB8z//0wm8RRuPE25rhnpvrFdZJJ5l9bd8vPXdRNkCrBA==",
       "dev": true,
       "requires": {
         "axios": "^1.6.8",

--- a/jest/package.json
+++ b/jest/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "buildkite-test-collector": "^1.7.3",
+    "buildkite-test-collector": "^1.8.0",
     "jest": "^29.7.0"
   },
   "scripts": {

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.48.2",
-        "buildkite-test-collector": "^1.7.3"
+        "buildkite-test-collector": "^1.8.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -55,10 +55,18 @@
       }
     },
     "node_modules/buildkite-test-collector": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.7.3.tgz",
-      "integrity": "sha512-4NJFY9h6r1gpF6Faxpxd/OPesHJQZNbFDtHSHDgzT6mJ8zteKM2jvNXRu0hP/+SO1pJ4oFyWr44x2WmbTTCn9Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/buildkite-test-collector/-/buildkite-test-collector-1.8.0.tgz",
+      "integrity": "sha512-N/J4tU+mac8JBwOupBM6Z03P462wG9t3h4uSp3wkvNB8z//0wm8RRuPE25rhnpvrFdZJJ5l9bd8vPXdRNkCrBA==",
       "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/jest",
+        "examples/jasmine",
+        "examples/mocha",
+        "examples/playwright",
+        "examples/cypress"
+      ],
       "dependencies": {
         "axios": "^1.6.8",
         "dotenv": "^16.0.2",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "devDependencies": {
     "@playwright/test": "^1.48.2",
-    "buildkite-test-collector": "^1.7.3"
+    "buildkite-test-collector": "^1.8.0"
   },
   "scripts": {
     "test": "playwright test"

--- a/playwright/playwright.config.js
+++ b/playwright/playwright.config.js
@@ -22,7 +22,12 @@ module.exports = defineConfig({
   reporter: [
     ['line'],
     // Send results to Test Engine
-    ['buildkite-test-collector/playwright/reporter'],
+    ['buildkite-test-collector/playwright/reporter', {
+      tags: {
+        "test.framework.name": "playwright",
+        "test.framework.version": require('playwright/package.json').version,
+      },
+    }],
     // Output results to a JSON file for Buildkite Test Engine Client to read
     ['json', { outputFile: process.env.BUILDKITE_TEST_ENGINE_RESULT_PATH }]
   ],


### PR DESCRIPTION
_Based on #6_

Upload `test.framework.name` and `test.framework.version` tags from JavaScript collector in the `cypress`, `jest`, and `playwright` examples.

Currently this is using/testing an unreleased branch¹ of `buildkite-test-collector`.

- [ ] Switch to the upcoming release of `buildkite-test-collector`  which supports upload tags.

Related:
- ¹ https://github.com/buildkite/test-collector-javascript/pull/100