### PR TITLE
[PIE-3326] Bump bktec version in test-engine-client-examples repo

### DIFF
--- a/cypress/bin/test
+++ b/cypress/bin/test
@@ -5,7 +5,7 @@ npm install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-BKTEC_VERSION=${BKTEC_VERSION:-1.2.0}
+BKTEC_VERSION=${BKTEC_VERSION:-1.3.3}
 apt-get update && apt-get install curl -y
 curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
 chmod +x ./bktec

--- a/jest/bin/test
+++ b/jest/bin/test
@@ -5,7 +5,7 @@ npm install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-BKTEC_VERSION=${BKTEC_VERSION:-1.2.0}
+BKTEC_VERSION=${BKTEC_VERSION:-1.3.3}
 curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
 chmod +x ./bktec
 

--- a/playwright/bin/test
+++ b/playwright/bin/test
@@ -5,7 +5,7 @@ npm install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-BKTEC_VERSION=${BKTEC_VERSION:-1.2.0}
+BKTEC_VERSION=${BKTEC_VERSION:-1.3.3}
 curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
 chmod +x ./bktec
 

--- a/rspec/bin/test
+++ b/rspec/bin/test
@@ -5,7 +5,7 @@ bundle install
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-BKTEC_VERSION=${BKTEC_VERSION:-1.2.0}
+BKTEC_VERSION=${BKTEC_VERSION:-1.3.3}
 curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
 chmod +x ./bktec
 


### PR DESCRIPTION
Bump to use to the latest version of bktec 1.3.3
