### PR TITLE
Python builkdite-test-collector v1.1.0 (just released)

### DIFF
--- a/pytest/setup.py
+++ b/pytest/setup.py
@@ -8,7 +8,7 @@ setup(
   extras_require={
     "dev": [
       "pytest>=7.0.0",
-      "buildkite-test-collector>=1.0.0rc1",
+      "buildkite-test-collector>=1.1.0",
     ],
   },
 )


### PR DESCRIPTION
Use (at least) v1.1.0 of the Python test collector, mostly to verify the release, and because it seems wrong to leave a `1.0.0rc1` version reference in here.

- https://github.com/buildkite/test-collector-python/releases/tag/v1.1.0
- https://github.com/buildkite/test-collector-python/pull/70
