### PR TITLE
Bump ruby test collector to v2.13.0

### DIFF
--- a/rspec/Gemfile.lock
+++ b/rspec/Gemfile.lock
@@ -1,7 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    buildkite-test_collector (2.9.0)
+    buildkite-test_collector (2.13.0)
+      concurrent-ruby
+    concurrent-ruby (1.3.6)
     diff-lcs (1.6.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/ruby-minitest/Gemfile.lock
+++ b/ruby-minitest/Gemfile.lock
@@ -1,7 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    buildkite-test_collector (2.9.0)
+    buildkite-test_collector (2.13.0)
+      concurrent-ruby
+    concurrent-ruby (1.3.6)
     minitest (5.25.4)
     rake (13.3.1)
 


### PR DESCRIPTION
The new version removes `./` from minitest file path, that will fix the non-optimal test plan for `bktec`.

Test Plans:
[before](https://buildkite.com/admin/organizations/buildkite/analytics_suites/test-engine-client-examples/test_plans/019cda99-eb83-7f35-81eb-c9c7882b32cd)
[after](https://buildkite.com/admin/organizations/buildkite/analytics_suites/test-engine-client-examples/test_plans/019cda9a-1da7-7b3f-b0d2-d048f1696f77)
