### PR TITLE
Location prefix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  BKTEC_VERSION: "2.3.0-rc.2"
+  BKTEC_VERSION: "2.3.0-rc.3"
 
 steps:
   - label: ":ruby: :rspec: Ruby: RSpec"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  BKTEC_VERSION: "2.1.3"
+  BKTEC_VERSION: "2.3.0-rc.2"
 
 steps:
   - label: ":ruby: :rspec: Ruby: RSpec"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,8 @@ steps:
   - label: ":ruby: :rspec: Ruby: RSpec"
     parallelism: 2
     command: "cd rspec && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -25,7 +26,8 @@ steps:
   - label: ":ruby: Ruby: Minitest"
     parallelism: 2
     command: "cd ruby-minitest && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -45,7 +47,8 @@ steps:
   - label: ":jest: Jest"
     parallelism: 2
     command: "cd jest && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -65,7 +68,8 @@ steps:
   - label: ":cypress: Cypress"
     parallelism: 2
     command: "cd cypress && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -87,7 +91,8 @@ steps:
   - label: ":playwright: Playwright"
     parallelism: 2
     command: "cd playwright && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -109,7 +114,8 @@ steps:
     artifact_paths:
       - pytest/result.json
     command: "cd pytest && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -131,7 +137,8 @@ steps:
     artifact_paths:
       - pytest/result.json
     command: "cd pytest-xdist && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -150,7 +157,8 @@ steps:
 
   - label: ":swift: Swift: XCTest (test-collector-swift)"
     command: "cd swift-xctest && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     env:
       BUILDKITE_ANALYTICS_TAGS: '{"test.framework.name":"xctest","language.name":"swift","custom.tag.from":"upload"}'
     plugins:
@@ -167,7 +175,8 @@ steps:
 
   - label: ":android: Android"
     command: "cd android && bin/test"
-    soft_fail: true
+    soft_fail:
+      - exit_status: 1
     plugins:
       - cluster-secrets#v1.0.0:
           variables:
@@ -184,7 +193,8 @@ steps:
       - label: ":jest: Jest (Retry Enabled)"
         parallelism: 2
         command: "cd jest && bin/test-with-retry"
-        soft_fail: true
+        soft_fail:
+          - exit_status: 1
         plugins:
           - cluster-secrets#v1.0.0:
               variables:
@@ -206,7 +216,8 @@ steps:
         artifact_paths:
           - pytest/result.json
         command: "cd pytest-tag-filters && bin/test"
-        soft_fail: true
+        soft_fail:
+          - exit_status: 1
         plugins:
           - cluster-secrets#v1.0.0:
               variables:

--- a/cypress/bin/test
+++ b/cypress/bin/test
@@ -10,8 +10,15 @@ if [ -z "${BKTEC_VERSION}" ]; then
   echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
   exit 1
 fi
-apt-get update && apt-get install curl -y
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
+BKTEC_URL="https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64"
+if command -v curl &> /dev/null; then
+  curl -L "$BKTEC_URL" -o ./bktec
+elif command -v wget &> /dev/null; then
+  wget -O ./bktec "$BKTEC_URL"
+else
+  echo "Error: neither curl nor wget found"
+  exit 16
+fi
 chmod +x ./bktec
 
 # Configure Buildkite Test Engine Client

--- a/jest/bin/test
+++ b/jest/bin/test
@@ -18,5 +18,7 @@ chmod +x ./bktec
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=jest
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=jest-result.json
 
+export BUILDKITE_ANALYTICS_LOCATION_PREFIX="jest"
+
 # Run Buildkite Test Engine Client
 ./bktec run

--- a/jest/bin/test-with-retry
+++ b/jest/bin/test-with-retry
@@ -22,5 +22,7 @@ export BUILDKITE_TEST_ENGINE_RESULT_PATH=jest-result.json
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=3
 export BUILDKITE_TEST_ENGINE_RETRY_CMD="npx jest {{testExamples}} --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 
+export BUILDKITE_ANALYTICS_LOCATION_PREFIX="jest"
+
 # Run Buildkite Test Engine Client
 ./bktec run

--- a/playwright/bin/test
+++ b/playwright/bin/test
@@ -18,5 +18,7 @@ chmod +x ./bktec
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=playwright
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/playwright-results.json
 
+export BUILDKITE_ANALYTICS_LOCATION_PREFIX="playwright"
+
 # Run Buildkite Test Engine Client
 ./bktec run

--- a/ruby-minitest/bin/test
+++ b/ruby-minitest/bin/test
@@ -19,4 +19,7 @@ chmod +x ./bktec
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
 export BUILDKITE_TEST_ENGINE_TEST_CMD="bundle exec rake test TEST_FILES='{{testExamples}}'"
 export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="**/*_test.rb"
+
+export BUILDKITE_ANALYTICS_LOCATION_PREFIX="ruby-minitest"
+
 ./bktec run


### PR DESCRIPTION
Set a location prefix for Jest, Playwright and Minitest to test new `bktec` location prefix support.

By setting the prefix via `BUILDKITE_ANALYTICS_LOCATION_PREFIX`, the execution data uploaded to TE will include this prefix and the test plan will include it with the correct estimated duration.

<img width="1167" height="701" alt="Screenshot 2026-03-12 at 3 36 05 PM" src="https://github.com/user-attachments/assets/ea340d83-7349-4ea8-aaea-c9e0d413f174" />

**Test Plans:**
[Jest](https://buildkite.com/admin/organizations/buildkite/analytics_suites/test-engine-client-examples/test_plans/019cdfe2-4810-7e46-8d33-ad1811936e27#test_plan)
[Playwright](https://buildkite.com/admin/organizations/buildkite/analytics_suites/test-engine-client-examples/test_plans/019cdfe2-442c-7bb1-ae79-6185e5aa2dcf#test_plan)
[Minitest](https://buildkite.com/admin/organizations/buildkite/analytics_suites/test-engine-client-examples/test_plans/019cdfe2-3d37-716c-9843-833074027bb4#test_plan)


