### PR TITLE
Add NUnit .NET example using `bktec` custom runner for test splitting

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -188,6 +188,7 @@ steps:
             - BUILDKITE_ANALYTICS_TOKEN
 
   - label: ":dotnet: NUnit"
+    parallelism: 2
     command: "cd nunit && bin/test"
     soft_fail:
       - exit_status: 1
@@ -195,6 +196,7 @@ steps:
       - cluster-secrets#v1.0.0:
           variables:
             BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
+            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
       - mise#v1.1.1:
           dir: nunit
       - test-collector#v1.11.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -192,8 +192,14 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
       - mise#v1.1.1:
           dir: nunit
+      - test-collector#v1.11.0:
+          files: "nunit/tests/MyLib.Tests/test-results/results.xml"
+          format: "junit"
 
   - group: "Additional bktec features"
     key: "jest-retry"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,6 +187,14 @@ steps:
           environment:
             - BUILDKITE_ANALYTICS_TOKEN
 
+  - label: ":dotnet: NUnit"
+    command: "cd nunit && bin/test"
+    soft_fail:
+      - exit_status: 1
+    plugins:
+      - mise#v1.1.1:
+          dir: nunit
+
   - group: "Additional bktec features"
     key: "jest-retry"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -202,6 +202,9 @@ steps:
       - test-collector#v1.11.0:
           files: "nunit/tests/MyLib.Tests/test-results/results.xml"
           format: "junit"
+          tags:
+            - "language.name=dotnet"
+            - "test.framework.name=nunit"
 
   - group: "Additional bktec features"
     key: "jest-retry"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@ node_modules/
 tmp/
 bktec
 
+# nunit / .NET
+nunit/**/bin/
+nunit/**/obj/
+test-results/
+*.user
+
 # pytest
 *.egg*
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,7 @@ tmp/
 bktec
 
 # nunit / .NET
-nunit/**/bin/
-nunit/**/obj/
 test-results/
-*.user
 
 # pytest
 *.egg*

--- a/nunit/.gitignore
+++ b/nunit/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/nunit/.gitignore
+++ b/nunit/.gitignore
@@ -1,1 +1,6 @@
 test-results/
+src/**/bin/
+src/**/obj/
+tests/**/bin/
+tests/**/obj/
+*.user

--- a/nunit/NUnitSpike.slnx
+++ b/nunit/NUnitSpike.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/MyLib/MyLib.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/MyLib.Tests/MyLib.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/nunit/README.md
+++ b/nunit/README.md
@@ -1,24 +1,38 @@
-# NUnit Spike
+# NUnit
 
-A minimal NUnit test suite for exploring test splitting, test selection, and related tooling.
+A .NET NUnit example demonstrating [Buildkite Test Engine](https://buildkite.com/docs/test-engine) test splitting using `bktec` with a custom runner.
+
+Since `bktec` doesn't have built-in NUnit support, this example uses `BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom` to split test files across parallel agents and map them to `dotnet test --filter` expressions.
 
 ## Structure
 
 ```
+bin/test              # Entry point: builds, installs bktec, configures custom runner
+bin/run-tests         # Custom runner invoked by bktec with test file paths
 src/MyLib/            # Library under test
-  Calculator.cs       # Basic arithmetic
-  StringUtils.cs      # String helpers (reverse, palindrome, word count)
-  Collections.cs      # Simple generic stack
-
-tests/MyLib.Tests/    # NUnit test project
-  CalculatorTests.cs  # 9 tests (incl. parameterized TestCase)
-  StringUtilsTests.cs # 9 tests (incl. parameterized TestCase)
-  SimpleStackTests.cs # 7 tests
+tests/MyLib.Tests/    # NUnit test project (25 tests across 3 files)
+mise.toml             # .NET SDK managed by mise
+NUnitSpike.slnx       # Solution file
 ```
 
-25 tests total.
+## How it works
 
-## Prerequisites
+1. `bin/test` builds the solution, installs `bktec`, and configures:
+   - `BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom`
+   - `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=tests/**/*Tests.cs`
+   - `BUILDKITE_TEST_ENGINE_TEST_CMD="bin/run-tests {{testExamples}}"`
+
+2. `bktec` discovers test files matching the pattern, requests a split plan from the Test Engine API, and invokes `bin/run-tests` with the files assigned to this node.
+
+3. `bin/run-tests` receives `.cs` file paths as arguments, extracts class names, and builds a `dotnet test --filter` expression to run only those test classes.
+
+## Pipeline
+
+The Buildkite pipeline step uses `parallelism: 2` and the [mise plugin](https://github.com/buildkite-plugins/mise-buildkite-plugin) (instead of Docker) to install the .NET SDK. The [test-collector plugin](https://github.com/buildkite-plugins/test-collector-buildkite-plugin) uploads JUnit XML results to Test Engine.
+
+## Local development
+
+### Prerequisites
 
 [mise](https://mise.jdx.dev/) manages the .NET SDK:
 
@@ -26,16 +40,14 @@ tests/MyLib.Tests/    # NUnit test project
 mise install
 ```
 
-## Run tests
+### Run tests
 
 ```sh
 dotnet test
 ```
 
-## Run tests with JUnit XML output
+### Run tests with JUnit XML output
 
 ```sh
 dotnet test --logger "junit;LogFilePath=test-results/results.xml"
 ```
-
-Results are written to `tests/MyLib.Tests/test-results/results.xml`.

--- a/nunit/README.md
+++ b/nunit/README.md
@@ -1,0 +1,41 @@
+# NUnit Spike
+
+A minimal NUnit test suite for exploring test splitting, test selection, and related tooling.
+
+## Structure
+
+```
+src/MyLib/            # Library under test
+  Calculator.cs       # Basic arithmetic
+  StringUtils.cs      # String helpers (reverse, palindrome, word count)
+  Collections.cs      # Simple generic stack
+
+tests/MyLib.Tests/    # NUnit test project
+  CalculatorTests.cs  # 9 tests (incl. parameterized TestCase)
+  StringUtilsTests.cs # 9 tests (incl. parameterized TestCase)
+  SimpleStackTests.cs # 7 tests
+```
+
+25 tests total.
+
+## Prerequisites
+
+[mise](https://mise.jdx.dev/) manages the .NET SDK:
+
+```sh
+mise install
+```
+
+## Run tests
+
+```sh
+dotnet test
+```
+
+## Run tests with JUnit XML output
+
+```sh
+dotnet test --logger "junit;LogFilePath=test-results/results.xml"
+```
+
+Results are written to `tests/MyLib.Tests/test-results/results.xml`.

--- a/nunit/bin/run-tests
+++ b/nunit/bin/run-tests
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Custom test runner for bktec.
+# bktec passes test file paths (e.g. tests/MyLib.Tests/CalculatorTests.cs) as arguments.
+# We extract class names and build a dotnet test --filter expression.
+
+if [ $# -eq 0 ]; then
+  echo "Usage: bin/run-tests <test-file> [test-file...]"
+  exit 1
+fi
+
+# Build a filter expression from the test file paths.
+# Each .cs file maps to a class name (filename without extension).
+filter_parts=()
+for file in "$@"; do
+  classname=$(basename "$file" .cs)
+  filter_parts+=("FullyQualifiedName~.${classname}")
+done
+
+# Join with " | " (OR)
+filter=$(IFS="|"; echo "${filter_parts[*]}")
+
+dotnet test --no-build --filter "$filter" --logger "junit;LogFilePath=test-results/results.xml"

--- a/nunit/bin/test
+++ b/nunit/bin/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet test --logger "junit;LogFilePath=test-results/results.xml"

--- a/nunit/bin/test
+++ b/nunit/bin/test
@@ -1,4 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-dotnet test --logger "junit;LogFilePath=test-results/results.xml"
+# Build the solution first so the custom runner can use --no-build
+dotnet build
+
+# Install Buildkite Test Engine Client
+# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
+if [ -z "${BKTEC_VERSION}" ]; then
+  echo "Error: BKTEC_VERSION environment variable is not set"
+  echo "Set it with: export BKTEC_VERSION=2.3.0-rc.3"
+  exit 1
+fi
+curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec
+chmod +x ./bktec
+
+# Configure Buildkite Test Engine Client
+# See https://buildkite.com/docs/test-engine/test-splitting/configuring
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="tests/**/*Tests.cs"
+export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/run-tests {{testExamples}}"
+
+# Run Buildkite Test Engine Client
+./bktec run

--- a/nunit/bin/test
+++ b/nunit/bin/test
@@ -6,7 +6,7 @@ dotnet build
 
 # Install Buildkite Test Engine Client
 # See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
+if [ -z "${BKTEC_VERSION:-}" ]; then
   echo "Error: BKTEC_VERSION environment variable is not set"
   echo "Set it with: export BKTEC_VERSION=2.3.0-rc.3"
   exit 1

--- a/nunit/mise.toml
+++ b/nunit/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+dotnet = "latest"

--- a/nunit/src/MyLib/Calculator.cs
+++ b/nunit/src/MyLib/Calculator.cs
@@ -1,0 +1,10 @@
+namespace MyLib;
+
+public class Calculator
+{
+    public int Add(int a, int b) => a + b;
+    public int Subtract(int a, int b) => a - b;
+    public int Multiply(int a, int b) => a * b;
+    public double Divide(int a, int b) =>
+        b == 0 ? throw new DivideByZeroException() : (double)a / b;
+}

--- a/nunit/src/MyLib/Collections.cs
+++ b/nunit/src/MyLib/Collections.cs
@@ -1,0 +1,25 @@
+namespace MyLib;
+
+public class SimpleStack<T>
+{
+    private readonly List<T> _items = [];
+
+    public int Count => _items.Count;
+    public bool IsEmpty => _items.Count == 0;
+
+    public void Push(T item) => _items.Add(item);
+
+    public T Pop()
+    {
+        if (IsEmpty) throw new InvalidOperationException("Stack is empty");
+        var item = _items[^1];
+        _items.RemoveAt(_items.Count - 1);
+        return item;
+    }
+
+    public T Peek()
+    {
+        if (IsEmpty) throw new InvalidOperationException("Stack is empty");
+        return _items[^1];
+    }
+}

--- a/nunit/src/MyLib/MyLib.csproj
+++ b/nunit/src/MyLib/MyLib.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/nunit/src/MyLib/StringUtils.cs
+++ b/nunit/src/MyLib/StringUtils.cs
@@ -1,0 +1,13 @@
+namespace MyLib;
+
+public static class StringUtils
+{
+    public static string Reverse(string input) =>
+        new(input.Reverse().ToArray());
+
+    public static bool IsPalindrome(string input) =>
+        input.Equals(Reverse(input), StringComparison.OrdinalIgnoreCase);
+
+    public static int WordCount(string input) =>
+        string.IsNullOrWhiteSpace(input) ? 0 : input.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+}

--- a/nunit/tests/MyLib.Tests/CalculatorTests.cs
+++ b/nunit/tests/MyLib.Tests/CalculatorTests.cs
@@ -1,0 +1,41 @@
+using MyLib;
+
+namespace MyLib.Tests;
+
+public class CalculatorTests
+{
+    private Calculator _calc = null!;
+
+    [SetUp]
+    public void SetUp() => _calc = new Calculator();
+
+    [Test]
+    public void Add_ReturnsSumOfTwoNumbers() =>
+        Assert.That(_calc.Add(2, 3), Is.EqualTo(5));
+
+    [Test]
+    public void Add_HandlesNegativeNumbers() =>
+        Assert.That(_calc.Add(-1, -2), Is.EqualTo(-3));
+
+    [Test]
+    public void Subtract_ReturnsDifference() =>
+        Assert.That(_calc.Subtract(10, 4), Is.EqualTo(6));
+
+    [Test]
+    public void Multiply_ReturnsProduct() =>
+        Assert.That(_calc.Multiply(3, 7), Is.EqualTo(21));
+
+    [Test]
+    public void Divide_ReturnsQuotient() =>
+        Assert.That(_calc.Divide(10, 4), Is.EqualTo(2.5));
+
+    [Test]
+    public void Divide_ByZero_Throws() =>
+        Assert.That(() => _calc.Divide(1, 0), Throws.TypeOf<DivideByZeroException>());
+
+    [TestCase(0, 0, 0)]
+    [TestCase(1, 1, 2)]
+    [TestCase(100, -50, 50)]
+    public void Add_Parameterized(int a, int b, int expected) =>
+        Assert.That(_calc.Add(a, b), Is.EqualTo(expected));
+}

--- a/nunit/tests/MyLib.Tests/MyLib.Tests.csproj
+++ b/nunit/tests/MyLib.Tests/MyLib.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MyLib\MyLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nunit/tests/MyLib.Tests/SimpleStackTests.cs
+++ b/nunit/tests/MyLib.Tests/SimpleStackTests.cs
@@ -1,0 +1,54 @@
+using MyLib;
+
+namespace MyLib.Tests;
+
+public class SimpleStackTests
+{
+    private SimpleStack<int> _stack = null!;
+
+    [SetUp]
+    public void SetUp() => _stack = new SimpleStack<int>();
+
+    [Test]
+    public void NewStack_IsEmpty() =>
+        Assert.That(_stack.IsEmpty, Is.True);
+
+    [Test]
+    public void Push_IncreasesCount()
+    {
+        _stack.Push(1);
+        Assert.That(_stack.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Pop_ReturnsLastPushedItem()
+    {
+        _stack.Push(1);
+        _stack.Push(2);
+        Assert.That(_stack.Pop(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Pop_DecreasesCount()
+    {
+        _stack.Push(1);
+        _stack.Pop();
+        Assert.That(_stack.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Pop_WhenEmpty_Throws() =>
+        Assert.That(() => _stack.Pop(), Throws.TypeOf<InvalidOperationException>());
+
+    [Test]
+    public void Peek_ReturnsTopWithoutRemoving()
+    {
+        _stack.Push(42);
+        Assert.That(_stack.Peek(), Is.EqualTo(42));
+        Assert.That(_stack.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Peek_WhenEmpty_Throws() =>
+        Assert.That(() => _stack.Peek(), Throws.TypeOf<InvalidOperationException>());
+}

--- a/nunit/tests/MyLib.Tests/StringUtilsTests.cs
+++ b/nunit/tests/MyLib.Tests/StringUtilsTests.cs
@@ -1,0 +1,33 @@
+using MyLib;
+
+namespace MyLib.Tests;
+
+public class StringUtilsTests
+{
+    [Test]
+    public void Reverse_ReversesString() =>
+        Assert.That(StringUtils.Reverse("hello"), Is.EqualTo("olleh"));
+
+    [Test]
+    public void Reverse_EmptyString_ReturnsEmpty() =>
+        Assert.That(StringUtils.Reverse(""), Is.EqualTo(""));
+
+    [Test]
+    public void IsPalindrome_True_ForPalindrome() =>
+        Assert.That(StringUtils.IsPalindrome("racecar"), Is.True);
+
+    [Test]
+    public void IsPalindrome_True_CaseInsensitive() =>
+        Assert.That(StringUtils.IsPalindrome("Madam"), Is.True);
+
+    [Test]
+    public void IsPalindrome_False_ForNonPalindrome() =>
+        Assert.That(StringUtils.IsPalindrome("hello"), Is.False);
+
+    [TestCase("hello world", 2)]
+    [TestCase("one", 1)]
+    [TestCase("  spaced  out  ", 2)]
+    [TestCase("", 0)]
+    public void WordCount_ReturnsCorrectCount(string input, int expected) =>
+        Assert.That(StringUtils.WordCount(input), Is.EqualTo(expected));
+}


### PR DESCRIPTION
Adds an NUnit/.NET example demonstrating test splitting with `bktec` using `BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom`.

Since `bktec` doesn't have built-in NUnit support, this example uses a custom runner to split `.cs` test files across parallel agents and map them to `dotnet test --filter` expressions.

## How it works

- `bin/test` builds the solution, installs `bktec`, and configures the custom runner with `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=tests/**/*Tests.cs`
- `bktec` discovers test files, gets a split plan from the API, and invokes `bin/run-tests` with the assigned files
- `bin/run-tests` extracts class names from the `.cs` file paths and builds a `dotnet test --filter "FullyQualifiedName~.CalculatorTests|..."` expression

## Pipeline details

- Uses the [mise plugin](https://github.com/buildkite-plugins/mise-buildkite-plugin) (instead of Docker) to install the .NET SDK
- `parallelism: 2` for test splitting across agents
- [test-collector plugin](https://github.com/buildkite-plugins/test-collector-buildkite-plugin) uploads JUnit XML results with `language.name=dotnet` and `test.framework.name=nunit` tags

## Test suite

25 NUnit tests across 3 files: `CalculatorTests`, `StringUtilsTests`, `SimpleStackTests`.