### PR TITLE
Bump bktec version to v2.3.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  BKTEC_VERSION: "2.3.0-rc.3"
+  BKTEC_VERSION: "2.3.0"
 
 steps:
   - label: ":ruby: :rspec: Ruby: RSpec"


### PR DESCRIPTION
Bumps BKTEC_VERSION from 2.3.0-rc.3 to 2.3.0.

No change, RC3 became the release: https://github.com/buildkite/test-engine-client/compare/v2.3.0-rc.3...v2.3.0