### PR TITLE
Use tests plugin for bktec examples

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
-env:
-  BKTEC_VERSION: "2.3.0"
-
 steps:
   - label: ":ruby: :rspec: Ruby: RSpec"
     parallelism: 2
@@ -8,20 +5,19 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: rspec
+          result-path: tmp/rspec.json
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "ruby:3.4-bookworm" # requires curl
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":ruby: Ruby: Minitest"
     parallelism: 2
@@ -29,20 +25,20 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: custom
+          test-cmd: "bundle exec rake test TEST_FILES='{{testExamples}}'"
+          test-file-pattern: "**/*_test.rb"
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "ruby:3.4-bookworm" # requires curl
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":jest: Jest"
     parallelism: 2
@@ -50,20 +46,19 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: jest
+          result-path: jest-result.json
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "node:23.1.0-bookworm"
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":cypress: Cypress"
     parallelism: 2
@@ -71,22 +66,20 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: cypress
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "cypress/included:13.15.1"
           entrypoint: ""
           shell: ["/bin/sh", "-e", "-c"]
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":playwright: Playwright"
     parallelism: 2
@@ -94,20 +87,19 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: playwright
+          result-path: tmp/playwright-results.json
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "mcr.microsoft.com/playwright:v1.48.1-noble"
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":pytest: pytest"
     parallelism: 2
@@ -117,20 +109,18 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: pytest
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "python:3.13.2-bookworm"
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":pytest: pytest with (xdist)"
     parallelism: 2
@@ -140,20 +130,18 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - docker#v5.11.0:
+      - tests#v1.0.0:
+          test-runner: pytest
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
+          client-os: linux
+          upload-results: false
+      - docker#v5.13.0:
           image: "python:3.13.2-bookworm"
-          # Pass pipeline env variables to the Docker container
-          # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
           propagate-environment: true
-          # Pass API access token and Test Engine suite token to the Docker container
-          environment:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-            - BKTEC_VERSION
 
   - label: ":pytest: :pants: pytest (Pants)"
     # Pants owns test discovery and execution; the buildkite-test-collector
@@ -210,18 +198,17 @@ steps:
     soft_fail:
       - exit_status: 1
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-      - mise#v1.1.1:
-          dir: nunit
-      - test-collector#v1.11.0:
-          files: "nunit/tests/MyLib.Tests/test-results/results.xml"
-          format: "junit"
+      - tests#v1.0.0:
+          test-runner: nunit
+          result-path: test-results/results.xml
+          test-file-pattern: "tests/**/*Tests.cs"
+          suite-slug: test-engine-client-examples
+          client-version: "2.8.1"
           tags:
             - "language.name=dotnet"
             - "test.framework.name=nunit"
+      - mise#v1.1.1:
+          dir: nunit
 
   - group: "Additional bktec features"
     key: "jest-retry"
@@ -232,20 +219,21 @@ steps:
         soft_fail:
           - exit_status: 1
         plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-                BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-          - docker#v5.11.0:
+          - tests#v1.0.0:
+              test-runner: jest
+              result-path: jest-result.json
+              retry-count: 3
+              retry-cmd: "npx jest {{testExamples}} --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
+              suite-slug: test-engine-client-examples
+              client-version: "2.8.1"
+              client-os: linux
+              upload-results: false
+          - docker#v5.13.0:
               image: "node:23.1.0-bookworm"
-              # Pass pipeline env variables to the Docker container
-              # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+              expand-volume-vars: true
+              volumes:
+                - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
               propagate-environment: true
-              # Pass API access token and Test Engine suite token to the Docker container
-              environment:
-                - BUILDKITE_ANALYTICS_TOKEN
-                - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-                - BKTEC_VERSION
 
       - label: ":pytest: pytest (tag filters)"
         parallelism: 2
@@ -255,17 +243,16 @@ steps:
         soft_fail:
           - exit_status: 1
         plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                BUILDKITE_ANALYTICS_TOKEN: test_engine_client_examples_suite_token
-                BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: test_engine_client_examples_api_token
-          - docker#v5.11.0:
+          - tests#v1.0.0:
+              test-runner: pytest
+              tag-filters: "component:frontend"
+              suite-slug: test-engine-client-examples
+              client-version: "2.8.1"
+              client-os: linux
+              upload-results: false
+          - docker#v5.13.0:
               image: "python:3.13.2-bookworm"
-              # Pass pipeline env variables to the Docker container
-              # See https://buildkite.com/docs/test-engine/test-splitting/configuring#using-the-test-engine-client-configure-environment-variables
+              expand-volume-vars: true
+              volumes:
+                - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
               propagate-environment: true
-              # Pass API access token and Test Engine suite token to the Docker container
-              environment:
-                - BUILDKITE_ANALYTICS_TOKEN
-                - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-                - BKTEC_VERSION

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,6 @@ steps:
           test-runner: rspec
           result-path: tmp/rspec.json
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -30,7 +29,6 @@ steps:
           test-cmd: "bundle exec rake test TEST_FILES='{{testExamples}}'"
           test-file-pattern: "**/*_test.rb"
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -50,7 +48,6 @@ steps:
           test-runner: jest
           result-path: jest-result.json
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -69,7 +66,6 @@ steps:
       - tests#v1.0.0:
           test-runner: cypress
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -91,7 +87,6 @@ steps:
           test-runner: playwright
           result-path: tmp/playwright-results.json
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -112,7 +107,6 @@ steps:
       - tests#v1.0.0:
           test-runner: pytest
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -133,7 +127,6 @@ steps:
       - tests#v1.0.0:
           test-runner: pytest
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           client-os: linux
           upload-results: false
       - docker#v5.13.0:
@@ -203,12 +196,32 @@ steps:
           result-path: test-results/results.xml
           test-file-pattern: "tests/**/*Tests.cs"
           suite-slug: test-engine-client-examples
-          client-version: "2.8.1"
           tags:
             - "language.name=dotnet"
             - "test.framework.name=nunit"
       - mise#v1.1.1:
           dir: nunit
+
+  - label: ":golang: Go test"
+    parallelism: 2
+    command: "cd go && bin/test"
+    soft_fail:
+      - exit_status: 1
+    plugins:
+      - tests#v1.0.0:
+          test-runner: gotest
+          result-path: tmp/gotest-result.xml
+          suite-slug: test-engine-client-examples
+          client-os: linux
+          tags:
+            - "language.name=go"
+            - "test.framework.name=go-test"
+      - docker#v5.13.0:
+          image: "golang:1.24-bookworm"
+          expand-volume-vars: true
+          volumes:
+            - "$$BUILDKITE_TEST_ENGINE_CLIENT_PATH:/usr/local/bin/bktec"
+          propagate-environment: true
 
   - group: "Additional bktec features"
     key: "jest-retry"
@@ -225,7 +238,6 @@ steps:
               retry-count: 3
               retry-cmd: "npx jest {{testExamples}} --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
               suite-slug: test-engine-client-examples
-              client-version: "2.8.1"
               client-os: linux
               upload-results: false
           - docker#v5.13.0:
@@ -247,7 +259,6 @@ steps:
               test-runner: pytest
               tag-filters: "component:frontend"
               suite-slug: test-engine-client-examples
-              client-version: "2.8.1"
               client-os: linux
               upload-results: false
           - docker#v5.13.0:

--- a/cypress/bin/test
+++ b/cypress/bin/test
@@ -3,27 +3,5 @@
 # Install node packages
 npm install
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-BKTEC_URL="https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64"
-if command -v curl &> /dev/null; then
-  curl -L "$BKTEC_URL" -o ./bktec
-elif command -v wget &> /dev/null; then
-  wget -O ./bktec "$BKTEC_URL"
-else
-  echo "Error: neither curl nor wget found"
-  exit 16
-fi
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=cypress
-
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/go/bin/test
+++ b/go/bin/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gotestsum generates the JUnit XML report consumed by bktec's Go runner.
+go install gotest.tools/gotestsum@v1.12.0
+export PATH="$(go env GOPATH)/bin:${PATH}"
+
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/go/calculator/calculator.go
+++ b/go/calculator/calculator.go
@@ -1,0 +1,13 @@
+package calculator
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func Divide(a, b int) (int, bool) {
+	if b == 0 {
+		return 0, false
+	}
+
+	return a / b, true
+}

--- a/go/calculator/calculator_test.go
+++ b/go/calculator/calculator_test.go
@@ -1,0 +1,25 @@
+package calculator
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	if got := Add(2, 3); got != 5 {
+		t.Fatalf("Add(2, 3) = %d, want 5", got)
+	}
+}
+
+func TestDivide(t *testing.T) {
+	got, ok := Divide(12, 3)
+	if !ok {
+		t.Fatal("Divide(12, 3) reported division failure")
+	}
+	if got != 4 {
+		t.Fatalf("Divide(12, 3) = %d, want 4", got)
+	}
+}
+
+func TestDivideByZero(t *testing.T) {
+	if _, ok := Divide(12, 0); ok {
+		t.Fatal("Divide(12, 0) succeeded, want failure")
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/buildkite/test-engine-client-examples/go
+
+go 1.24

--- a/go/textutil/textutil.go
+++ b/go/textutil/textutil.go
@@ -1,0 +1,20 @@
+package textutil
+
+import "strings"
+
+func Normalize(input string) string {
+	return strings.ToLower(strings.TrimSpace(input))
+}
+
+func IsPalindrome(input string) bool {
+	normalized := Normalize(input)
+	runes := []rune(normalized)
+
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		if runes[i] != runes[j] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/go/textutil/textutil_test.go
+++ b/go/textutil/textutil_test.go
@@ -1,0 +1,21 @@
+package textutil
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	if got := Normalize("  Buildkite  "); got != "buildkite" {
+		t.Fatalf("Normalize() = %q, want %q", got, "buildkite")
+	}
+}
+
+func TestIsPalindrome(t *testing.T) {
+	if !IsPalindrome("Racecar") {
+		t.Fatal("Racecar should be a palindrome")
+	}
+}
+
+func TestIsNotPalindrome(t *testing.T) {
+	if IsPalindrome("pipeline") {
+		t.Fatal("pipeline should not be a palindrome")
+	}
+}

--- a/jest/bin/test
+++ b/jest/bin/test
@@ -3,22 +3,7 @@
 # Install node packages
 npm install
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=jest
-export BUILDKITE_TEST_ENGINE_RESULT_PATH=jest-result.json
-
 export BUILDKITE_ANALYTICS_LOCATION_PREFIX="jest"
 
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/jest/bin/test-with-retry
+++ b/jest/bin/test-with-retry
@@ -3,26 +3,7 @@
 # Install node packages
 npm install
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=jest
-export BUILDKITE_TEST_ENGINE_RESULT_PATH=jest-result.json
-
-# Configure retry settings for flaky test handling
-export BUILDKITE_TEST_ENGINE_RETRY_COUNT=3
-export BUILDKITE_TEST_ENGINE_RETRY_CMD="npx jest {{testExamples}} --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
-
 export BUILDKITE_ANALYTICS_LOCATION_PREFIX="jest"
 
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/nunit/README.md
+++ b/nunit/README.md
@@ -6,7 +6,6 @@ A .NET NUnit example demonstrating [Buildkite Test Engine](https://buildkite.com
 
 ```
 bin/test              # Entry point: builds, then runs bktec configured by the tests plugin
-bin/run-tests         # Legacy custom runner helper retained for reference
 src/MyLib/            # Library under test
 tests/MyLib.Tests/    # NUnit test project (25 tests across 3 files)
 mise.toml             # .NET SDK managed by mise

--- a/nunit/README.md
+++ b/nunit/README.md
@@ -1,14 +1,12 @@
 # NUnit
 
-A .NET NUnit example demonstrating [Buildkite Test Engine](https://buildkite.com/docs/test-engine) test splitting using `bktec` with a custom runner.
-
-Since `bktec` doesn't have built-in NUnit support, this example uses `BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom` to split test files across parallel agents and map them to `dotnet test --filter` expressions.
+A .NET NUnit example demonstrating [Buildkite Test Engine](https://buildkite.com/docs/test-engine) test splitting using `bktec` with the built-in NUnit runner.
 
 ## Structure
 
 ```
-bin/test              # Entry point: builds, installs bktec, configures custom runner
-bin/run-tests         # Custom runner invoked by bktec with test file paths
+bin/test              # Entry point: builds, then runs bktec configured by the tests plugin
+bin/run-tests         # Legacy custom runner helper retained for reference
 src/MyLib/            # Library under test
 tests/MyLib.Tests/    # NUnit test project (25 tests across 3 files)
 mise.toml             # .NET SDK managed by mise
@@ -17,18 +15,18 @@ NUnitSpike.slnx       # Solution file
 
 ## How it works
 
-1. `bin/test` builds the solution, installs `bktec`, and configures:
-   - `BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom`
+1. The Buildkite pipeline's `tests#v1.0.0` plugin installs `bktec`, authenticates with OIDC, and configures:
+   - `BUILDKITE_TEST_ENGINE_TEST_RUNNER=nunit`
    - `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=tests/**/*Tests.cs`
-   - `BUILDKITE_TEST_ENGINE_TEST_CMD="bin/run-tests {{testExamples}}"`
+   - `BUILDKITE_TEST_ENGINE_RESULT_PATH=test-results/results.xml`
 
-2. `bktec` discovers test files matching the pattern, requests a split plan from the Test Engine API, and invokes `bin/run-tests` with the files assigned to this node.
+2. `bin/test` builds the solution once with `dotnet build`, then runs `bktec run`.
 
-3. `bin/run-tests` receives `.cs` file paths as arguments, extracts class names, and builds a `dotnet test --filter` expression to run only those test classes.
+3. `bktec` discovers test files matching the pattern, requests a split plan from the Test Engine API, and runs `dotnet test --no-build --filter {{testFilter}} --logger junit;LogFilePath={{resultPath}}` for the files assigned to this node.
 
 ## Pipeline
 
-The Buildkite pipeline step uses `parallelism: 2` and the [mise plugin](https://github.com/buildkite-plugins/mise-buildkite-plugin) (instead of Docker) to install the .NET SDK. The [test-collector plugin](https://github.com/buildkite-plugins/test-collector-buildkite-plugin) uploads JUnit XML results to Test Engine.
+The Buildkite pipeline step uses `parallelism: 2`, the [Tests plugin](https://github.com/buildkite-plugins/tests-buildkite-plugin) to install/configure `bktec`, and the [mise plugin](https://github.com/buildkite-plugins/mise-buildkite-plugin) (instead of Docker) to install the .NET SDK. `bktec` uploads JUnit XML results to Test Engine directly.
 
 ## Local development
 

--- a/nunit/bin/test
+++ b/nunit/bin/test
@@ -4,16 +4,5 @@ set -euo pipefail
 # Build the solution first so bktec can use --no-build
 dotnet build
 
-# Install Buildkite Test Engine Client from unreleased nunit-runner branch
-# See https://github.com/buildkite/test-engine-client/pull/39
-GOBIN="$(pwd)" go install github.com/buildkite/test-engine-client@nunit-runner
-mv test-engine-client bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=nunit
-export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="tests/**/*Tests.cs"
-export BUILDKITE_TEST_ENGINE_RESULT_PATH=test-results/results.xml
-
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/playwright/bin/test
+++ b/playwright/bin/test
@@ -3,22 +3,7 @@
 # Install node packages
 npm install
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=playwright
-export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/playwright-results.json
-
 export BUILDKITE_ANALYTICS_LOCATION_PREFIX="playwright"
 
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/pytest-tag-filters/bin/test
+++ b/pytest-tag-filters/bin/test
@@ -5,19 +5,5 @@ set -e
 # Install packages
 pip install -e '.[dev]'
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=pytest
-
-# Run Buildkite Test Engine Client
-./bktec run --tag-filters "component:frontend"
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/pytest-xdist/bin/test
+++ b/pytest-xdist/bin/test
@@ -5,19 +5,5 @@ set -e
 # Install packages
 pip install -e '.[dev]'
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=pytest
-
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/pytest/bin/test
+++ b/pytest/bin/test
@@ -5,19 +5,5 @@ set -e
 # Install packages
 pip install -e '.[dev]'
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=pytest
-
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/rspec/bin/test
+++ b/rspec/bin/test
@@ -3,20 +3,5 @@
 # Install gems
 bundle install
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec 
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=rspec
-export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/rspec.json
-
-# Run Buildkite Test Engine Client
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run

--- a/ruby-minitest/bin/test
+++ b/ruby-minitest/bin/test
@@ -4,22 +4,7 @@ set -euo pipefail
 # Install gems
 bundle install
 
-# Install Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/client-installation
-if [ -z "${BKTEC_VERSION}" ]; then
-  echo "Error: BKTEC_VERSION environment variable is not set"
-  echo "Set it with: export BKTEC_VERSION=2.1.0-rc.3"
-  exit 1
-fi
-curl -L "https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_amd64" -o ./bktec
-chmod +x ./bktec
-
-# Configure Buildkite Test Engine Client
-# See https://buildkite.com/docs/test-engine/test-splitting/configuring
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
-export BUILDKITE_TEST_ENGINE_TEST_CMD="bundle exec rake test TEST_FILES='{{testExamples}}'"
-export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="**/*_test.rb"
-
 export BUILDKITE_ANALYTICS_LOCATION_PREFIX="ruby-minitest"
 
-./bktec run
+# Run Buildkite Test Engine Client configured by the tests Buildkite plugin
+bktec run


### PR DESCRIPTION
## Summary

- migrate bktec-backed examples to the `tests#v1.0.0` Buildkite plugin
- simplify example `bin/test` scripts so the plugin owns bktec installation/configuration
- add a Go test example using the plugin's `gotest` runner

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".buildkite/pipeline.yml"); puts "yaml ok"'`
- `buildkite-agent pipeline upload --dry-run --no-interpolation --agent-access-token dummy .buildkite/pipeline.yml`
- `go test ./...` from `go/`

## Notes

- Existing collector-backed examples set `upload-results: false` to avoid double uploads.
- Docker-based bktec examples now mount the plugin-installed client via `BUILDKITE_TEST_ENGINE_CLIENT_PATH`.
