### PR TITLE
Bump pytest collector version

### DIFF
--- a/pytest-tag-filters/setup.py
+++ b/pytest-tag-filters/setup.py
@@ -8,7 +8,7 @@ setup(
   extras_require={
     "dev": [
       "pytest>=7.0.0",
-      "buildkite-test-collector>=1.3.0",
+      "buildkite-test-collector>=1.6.0",
     ],
   },
 )

--- a/pytest/setup.py
+++ b/pytest/setup.py
@@ -9,7 +9,7 @@ setup(
     "dev": [
       "pytest>=7.0.0",
       "pytest-xdist>=3.0.0",
-      "buildkite-test-collector>=1.1.0",
+      "buildkite-test-collector>=1.6.0",
     ],
   },
 )


### PR DESCRIPTION
Bump to [v1.6.0](https://github.com/buildkite/test-collector-python/releases/tag/v1.6.0)